### PR TITLE
Add CLI entry point for core logic

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,25 @@
+import sys
+
+
+def main(argv=None):
+    args = sys.argv[1:] if argv is None else argv
+    if not args:
+        print('Usage: python -m cli "your prompt"')
+        raise SystemExit(2)
+    prompt = " ".join(args)
+    try:
+        from core.logic import respond
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    try:
+        result = respond(prompt)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    if result is not None:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `cli.py` to allow command-line interaction with `core.logic.respond`
- emit usage message and exit status 2 when no prompt is supplied
- handle import and runtime errors gracefully

## Testing
- `python -m py_compile cli.py`
- `python - <<'PY'
import subprocess; res = subprocess.run(['python','-m','cli'], capture_output=True, text=True); print('returncode', res.returncode); print('stdout:', res.stdout); print('stderr:', res.stderr)
PY`
- `python - <<'PY'
import subprocess; res = subprocess.run(['python','-m','cli','test'], capture_output=True, text=True); print('returncode', res.returncode); print('stdout:', res.stdout); print('stderr:', res.stderr)
PY`
- `pip install core` *(failed: No matching distribution found for core)*

------
https://chatgpt.com/codex/tasks/task_b_689877ca887c8329b5220c62f0a01727