### PR TITLE
Add core logic module and unit tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# core package

--- a/core/logic.py
+++ b/core/logic.py
@@ -1,0 +1,45 @@
+import re
+
+
+def sanitize_prompt(prompt: str) -> str:
+    """Trim leading/trailing spaces and collapse multiple internal whitespace.
+
+    Args:
+        prompt: Raw prompt string.
+
+    Returns:
+        Sanitized prompt with single spaces separating words.
+    """
+    # Strip leading/trailing whitespace
+    trimmed = prompt.strip()
+    # Collapse all sequences of whitespace into a single space
+    return re.sub(r"\s+", " ", trimmed)
+
+
+def respond(prompt: str) -> str:
+    """Simple responder that acknowledges the prompt.
+
+    Args:
+        prompt: Already sanitized prompt.
+
+    Returns:
+        "Empty prompt." if the sanitized prompt is empty,
+        otherwise an acknowledgement string.
+    """
+    if not prompt:
+        return "Empty prompt."
+    return f"ACK:{prompt}"
+
+
+def process_pipeline(raw: str) -> dict:
+    """Process the full logic pipeline.
+
+    Args:
+        raw: Raw user input.
+
+    Returns:
+        dict: mapping of original input, sanitized version and response.
+    """
+    clean = sanitize_prompt(raw)
+    output = respond(clean)
+    return {"input": raw, "clean": clean, "output": output}

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from core.logic import sanitize_prompt, respond, process_pipeline
+
+
+def test_sanitize_prompt_collapses_spaces_and_trims():
+    raw = "  hello   world "
+    assert sanitize_prompt(raw) == "hello world"
+
+
+def test_respond_empty_prompt_returns_message():
+    assert respond("") == "Empty prompt."
+
+
+def test_respond_ping_returns_ack():
+    assert respond("ping") == "ACK:ping"
+
+
+def test_process_pipeline_returns_coherent_dict():
+    data = process_pipeline("  hi  ")
+    assert data == {"input": "  hi  ", "clean": "hi", "output": "ACK:hi"}


### PR DESCRIPTION
## Summary
- implement core logic helpers for prompt sanitation and response
- add pytest suite covering sanitize_prompt, respond, and process_pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689877fe00188329807871baafca2148