### PR TITLE
Add pyproject.toml for tooling configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "assistant-gui"
+version = "0.1.0"
+requires-python = ">=3.10"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+strict = true
+warn_unused_ignores = true
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "UP", "B"]


### PR DESCRIPTION
## Summary
- add pyproject.toml defining build system and project metadata
- configure pytest, mypy, and ruff settings

## Testing
- `pytest -q`
- `mypy .` *(fails: Expected an indented block after function definition on line 318)*
- `ruff check .` *(fails: line too long and syntax errors in assistantGUI.py)*

------
https://chatgpt.com/codex/tasks/task_b_68987848a25c83299db55169b430effc