### PR TITLE
Add end-to-end tests for CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+
+def run_cli(*args):
+    """Helper to execute the CLI module with given arguments."""
+    return subprocess.run(
+        [sys.executable, "-m", "cli", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_ping_command_returns_ack():
+    """`python -m cli ping` should return exit code 0 and ACK the argument."""
+    result = run_cli("ping")
+    assert result.returncode == 0
+    assert "ACK:ping" in result.stdout
+
+
+def test_missing_argument_shows_usage():
+    """Running `python -m cli` without arguments should error with usage info."""
+    result = run_cli()
+    assert result.returncode == 2
+    assert "usage" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- add pytest-based end-to-end tests invoking the CLI via `python -m cli`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cli')*

------
https://chatgpt.com/codex/tasks/task_b_68987827f8608329b05959e572959c15