### PR TITLE
Set Go module to version 1.22

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package codexgpt provides the root module documentation.
+package codexgpt

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module codexgpt
+
+go 1.22


### PR DESCRIPTION
## Summary
- add a Go module definition that targets the published Go 1.22 toolchain
- document the root package so `go test` can enumerate the module

## Testing
- go mod tidy
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68cb0f68c19c83298c21c5370b817113